### PR TITLE
fix: Jenkinsfile BRANCH_NAME 인식 문제 및 Docker 이미지 태깅 오류 해결

### DIFF
--- a/jenkinsfile
+++ b/jenkinsfile
@@ -67,7 +67,8 @@ pipeline {
         stage('Build Docker Image') {
             steps {
                 script {
-                    dockerImage = docker.build("myapp:${env.BRANCH_NAME}")
+                    def imageTag = env.BRANCH_NAME ? env.BRANCH_NAME : "latest"
+                    def dockerImage = docker.build("myapp:${imageTag}")
                 }
             }
         }


### PR DESCRIPTION
- Jenkins `when { branch 'dev' }` 조건을 `expression { env.BRANCH_NAME == 'dev' }`로 수정하여 브랜치 인식 문제 해결
- Docker 빌드 시 이미지 태그가 `null`로 설정되는 문제 해결 (`myapp:latest` 기본 태그 추가)
- Jenkins Pipeline 내 `def` 키워드 추가하여 메모리 누수 방지