### PR TITLE
fix: 학년/학기/졸업 구분 로직 수정 및 ExecutiveHistoryMapper 리팩터링

### DIFF
--- a/src/main/java/org/nova/backend/member/application/dto/response/ExecutiveHistoryResponse.java
+++ b/src/main/java/org/nova/backend/member/application/dto/response/ExecutiveHistoryResponse.java
@@ -20,4 +20,6 @@ public class ExecutiveHistoryResponse {
     private String phone;
     private String grade;
     private String semester;
+    private boolean isGraduation;
+    private Integer graduationYear;
 }

--- a/src/main/java/org/nova/backend/member/application/mapper/ExecutiveHistoryMapper.java
+++ b/src/main/java/org/nova/backend/member/application/mapper/ExecutiveHistoryMapper.java
@@ -30,11 +30,14 @@ public class ExecutiveHistoryMapper {
     }
 
     public ExecutiveHistoryResponse toResponse(ExecutiveHistory executiveHistory) {
-        ProfilePhotoResponse profilePhotoResponse = executiveHistory.getMember() != null ?
-                memberProfilePhotoMapper.toResponse(executiveHistory.getMember().getProfilePhoto())
-                : memberProfilePhotoMapper.toResponse(null);
-
         Member executive = executiveHistory.getMember();
+        ProfilePhotoResponse profilePhotoResponse = memberProfilePhotoMapper.toResponse(
+                executive != null ? executive.getProfilePhoto() : null
+        );
+
+        String gradeText = getGradeText(executive);
+        String semesterText = getSemesterText(executive);
+        Integer graduationYear = getGraduationYear(executive);
 
         return new ExecutiveHistoryResponse(
                 executiveHistory.getId(),
@@ -45,9 +48,28 @@ public class ExecutiveHistoryMapper {
                 executive != null ? executive.getStudentNumber() : null,
                 profilePhotoResponse,
                 executive != null ? executive.getPhone() : null,
-                executive != null ? executive.getGrade() + "학년" : null,
-                executive != null ? executive.getSemester() + "학기" : null
+                gradeText,
+                semesterText,
+                executive != null && executive.isGraduation(),
+                graduationYear
         );
     }
 
+    private String getGradeText(Member member) {
+        if (member == null) return null;
+        if (member.isGraduation()) return "졸업생";
+        if (member.getGrade() >= 5) return "초과 학기";
+        return member.getGrade() + "학년";
+    }
+
+    private String getSemesterText(Member member) {
+        if (member == null || member.isGraduation() || member.getGrade() >= 5) return null;
+        int s = member.getSemester();
+        return (s >= 1 && s <= 2) ? s + "학기" : "1학기";
+    }
+
+    private Integer getGraduationYear(Member member) {
+        if (member == null || !member.isGraduation() || member.getGraduation() == null) return null;
+        return member.getGraduation().getYear();
+    }
 }

--- a/src/main/java/org/nova/backend/member/application/mapper/GradeSemesterYearMapper.java
+++ b/src/main/java/org/nova/backend/member/application/mapper/GradeSemesterYearMapper.java
@@ -25,11 +25,14 @@ public class GradeSemesterYearMapper {
      * @return ex) 1,2,..
      */
     public int toIntGrade(String stringGrade) {
-        if (stringGrade == null || stringGrade.equals("초과학기") || stringGrade.equals("초과 학기")) {
-            return 0;
+        if (stringGrade == null) return 0;
+
+        if (stringGrade.equals("초과학기") || stringGrade.equals("초과 학기")) {
+            return 5;
         }
         return Integer.parseInt(String.valueOf(stringGrade.charAt(0)));
     }
+
 
     /**
      * @param stringSemester 1학기, 2학기

--- a/src/main/java/org/nova/backend/member/application/mapper/MemberMapper.java
+++ b/src/main/java/org/nova/backend/member/application/mapper/MemberMapper.java
@@ -40,14 +40,17 @@ public class MemberMapper {
     }
 
     public MemberResponse toResponse(Member member, ProfilePhoto profilePhoto) {
+        String gradeStr = formatGrade(member.getGrade());
+        String semesterStr = member.getSemester() == 0 ? "" : member.getSemester() + "학기";
+
         return new MemberResponse(
                 member.getId(),
                 member.getStudentNumber(),
                 member.getName(),
                 member.getEmail(),
                 member.isGraduation(),
-                member.getGrade() <= 4 ? member.getGrade() + "학년" : "초과 학기",
-                member.getSemester() + "학기",
+                gradeStr,
+                semesterStr,
                 member.isAbsence(),
                 profilePhotoMapper.toResponse(profilePhoto),
                 member.getPhone(),
@@ -58,14 +61,17 @@ public class MemberMapper {
     }
 
     public MemberForListResponse toResponseForList(Member member, ProfilePhoto profilePhoto) {
+        String gradeStr = formatGrade(member.getGrade());
+        String semesterStr = member.getSemester() == 0 ? "" : member.getSemester() + "학기";
+
         return new MemberForListResponse(
                 member.getId(),
                 member.getStudentNumber(),
                 member.getName(),
                 member.getEmail(),
                 member.isGraduation(),
-                member.getGrade() <= 4 ? member.getGrade() + "학년" : "초과 학기",
-                member.getSemester() + "학기",
+                gradeStr,
+                semesterStr,
                 member.isAbsence(),
                 profilePhotoMapper.toResponse(profilePhoto),
                 member.getPhone()
@@ -74,14 +80,17 @@ public class MemberMapper {
 
     public MemberWithGraduationYearResponse toResponseWithGraduationYear(Member member, ProfilePhoto profilePhoto,
                                                                          int graduationYear) {
+        String gradeStr = formatGrade(member.getGrade());
+        String semesterStr = member.getSemester() == 0 ? "" : member.getSemester() + "학기";
+
         return new MemberWithGraduationYearResponse(
                 member.getId(),
                 member.getStudentNumber(),
                 member.getName(),
                 member.getEmail(),
                 member.isGraduation(),
-                member.getGrade() <= 4 ? member.getGrade() + "학년" : "초과 학기",
-                member.getSemester() + "학기",
+                gradeStr,
+                semesterStr,
                 member.isAbsence(),
                 profilePhotoMapper.toResponse(profilePhoto),
                 member.getPhone(),
@@ -92,4 +101,7 @@ public class MemberMapper {
         );
     }
 
+    private String formatGrade(int grade) {
+        return grade >= 5 ? "초과학기" : grade + "학년";
+    }
 }

--- a/src/main/java/org/nova/backend/member/application/mapper/PendingMemberMapper.java
+++ b/src/main/java/org/nova/backend/member/application/mapper/PendingMemberMapper.java
@@ -42,6 +42,8 @@ public class PendingMemberMapper {
     }
 
     public PendingMemberResponse toResponse(PendingMember pendingMember, ProfilePhoto profilePhoto) {
+        String gradeStr = formatGrade(pendingMember.getGrade());
+        String semesterStr = pendingMember.getSemester() == 0 ? "" : pendingMember.getSemester() + "학기";
 
         return new PendingMemberResponse(
                 pendingMember.getId(),
@@ -49,8 +51,8 @@ public class PendingMemberMapper {
                 pendingMember.getName(),
                 pendingMember.getEmail(),
                 pendingMember.isGraduation(),
-                pendingMember.getGrade() <= 4 ? pendingMember.getGrade() + "학년" : "초과 학기",
-                pendingMember.getSemester() + "학기",
+                gradeStr,
+                semesterStr,
                 pendingMember.isAbsence(),
                 profilePhotoMapper.toResponse(profilePhoto),
                 pendingMember.getPhone(),
@@ -60,4 +62,7 @@ public class PendingMemberMapper {
         );
     }
 
+    private String formatGrade(int grade) {
+        return grade >= 5 ? "초과학기" : grade + "학년";
+    }
 }


### PR DESCRIPTION
### 변경 목적
- 학년/학기/졸업 여부가 혼동되지 않도록 명확하게 표현되도록 로직을 정비
---

### 주요 변경 사항
- `초과학기`는 grade=5로 매핑하도록 변경 (`toIntGrade`)
- 출력 시 grade >= 5 → "초과학기", graduation = true → "졸업생"으로 구분 출력
- 졸업생인 경우 semester를 null로 출력
- `ExecutiveHistoryMapper`의 grade/semester/graduationYear 출력 로직 분리 및 리팩터링
  - nullable Boolean → 기본형 boolean으로 변경하여 NPE 방지
  - Cognitive complexity 개선을 위해 메서드 분리