### PR TITLE
 feat: Prometheus 모니터링 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/org/nova/backend/shared/config/SecurityConfig.java
+++ b/src/main/java/org/nova/backend/shared/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
 
 import java.util.Set;
 
@@ -67,6 +68,9 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers("/files/public/**").permitAll();
+
+                    auth.requestMatchers("/actuator/prometheus")
+                            .access(new WebExpressionAuthorizationManager("hasIpAddress('127.0.0.1') or hasIpAddress('::1')"));
 
                     //건의 게시판 관련 권한
                     configureSuggestionBoardPermissions(auth);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,13 @@ management:
   health:
     mail:
       enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: backend
 
 file:
   storage:


### PR DESCRIPTION
 ## 변경 내용
  - Micrometer Prometheus registry 의존성 추가하고 actuator prometheus 엔드포인트를 health/info와 함께 노출
  - 로컬 IP로만 접근 허용
  - 관리용 메트릭에 application 태그 설정