### PR TITLE
Perf: 캐시로 사진 게시글 조회시 이미지 메타 계산 속도 개선

### DIFF
--- a/src/main/java/org/nova/backend/board/clubArchive/application/service/ImageFileService.java
+++ b/src/main/java/org/nova/backend/board/clubArchive/application/service/ImageFileService.java
@@ -2,6 +2,8 @@ package org.nova.backend.board.clubArchive.application.service;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
@@ -11,8 +13,11 @@ import org.nova.backend.board.clubArchive.application.dto.response.ImageResponse
 import org.nova.backend.board.clubArchive.domain.exception.PictureDomainException;
 import org.nova.backend.board.common.application.port.in.FileUseCase;
 import org.nova.backend.board.common.domain.model.entity.File;
+import org.nova.backend.board.util.FileCacheKeyConstants;
+import org.nova.backend.board.util.FileUtil;
 import org.nova.backend.shared.constants.FilePathConstants;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -20,10 +25,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ImageFileService {
     private final FileUseCase fileUseCase;
+    private final StringRedisTemplate redisTemplate;
 
     @Value("${app.domain}")
     private String appDomain;
 
+    @Value("${file.storage.path}")
+    private String fileStoragePath;
     /**
      * 이미지 파일 정보 변환 (width, height 포함)
      */
@@ -33,14 +41,10 @@ public class ImageFileService {
         int height = 0;
 
         if (isImage) {
-            try {
-                BufferedImage image = ImageIO.read(new java.io.File(file.getFilePath()));
-                if (image != null) {
-                    width = image.getWidth();
-                    height = image.getHeight();
-                }
-            } catch (IOException e) {
-                throw new PictureDomainException("이미지 크기 정보를 불러올 수 없습니다.",HttpStatus.BAD_REQUEST);
+            int[] size = getImageSize(file);
+            if (size.length == 2) {
+                width = size[0];
+                height = size[1];
             }
         }
 
@@ -62,6 +66,52 @@ public class ImageFileService {
     boolean isImageFile(String filename) {
         String lowerCase = filename.toLowerCase();
         return lowerCase.endsWith(".jpg") || lowerCase.endsWith(".jpeg") || lowerCase.endsWith(".png") || lowerCase.endsWith(".gif") || lowerCase.endsWith(".bmp") || lowerCase.endsWith(".webp");
+    }
+
+    private int[] getImageSize(File file) {
+        String cacheKey = FileCacheKeyConstants.imageMetaKey(file.getId());
+        String cachedSize = redisTemplate.opsForValue().get(cacheKey);
+        int[] parsed = parseCachedSize(cachedSize);
+        if (parsed.length == 2) {
+            return parsed;
+        }
+
+        int[] size = readImageSize(file);
+        if (size.length == 2 && size[0] > 0 && size[1] > 0) {
+            redisTemplate.opsForValue().set(cacheKey, size[0] + "x" + size[1]);
+        }
+        return size;
+    }
+
+    private int[] parseCachedSize(String cachedSize) {
+        if (cachedSize == null || cachedSize.isBlank()) {
+            return new int[0];
+        }
+        String[] parts = cachedSize.split("x");
+        if (parts.length != 2) {
+            return new int[0];
+        }
+        try {
+            return new int[]{Integer.parseInt(parts[0]), Integer.parseInt(parts[1])};
+        } catch (NumberFormatException e) {
+            return new int[0];
+        }
+    }
+
+    private int[] readImageSize(File file) {
+        String extension = FileUtil.getFileExtension(file.getOriginalFilename());
+        Path publicPath = Paths.get(fileStoragePath, FilePathConstants.PUBLIC_FOLDER, file.getId() + "." + extension);
+        Path sourcePath = Files.exists(publicPath) ? publicPath : Paths.get(file.getFilePath());
+
+        try {
+            BufferedImage image = ImageIO.read(sourcePath.toFile());
+            if (image == null) {
+                throw new PictureDomainException("이미지 크기 정보를 불러올 수 없습니다.", HttpStatus.BAD_REQUEST);
+            }
+            return new int[]{image.getWidth(), image.getHeight()};
+        } catch (IOException e) {
+            throw new PictureDomainException("이미지 크기 정보를 불러올 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 
     /**

--- a/src/main/java/org/nova/backend/board/common/application/service/FileService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/FileService.java
@@ -1,26 +1,20 @@
 package org.nova.backend.board.common.application.service;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
-import org.nova.backend.board.util.ImageOptimizerUtil;
-import org.nova.backend.member.domain.exception.MemberDomainException;
-import org.nova.backend.shared.constants.FilePathConstants;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.HttpStatus;
-import org.springframework.transaction.annotation.Transactional;
-import org.nova.backend.board.util.FileStorageUtil;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.nova.backend.board.common.application.dto.response.FileResponse;
 import org.nova.backend.board.common.application.port.in.FileUseCase;
@@ -29,13 +23,22 @@ import org.nova.backend.board.common.application.port.out.FilePersistencePort;
 import org.nova.backend.board.common.domain.exception.FileDomainException;
 import org.nova.backend.board.common.domain.model.entity.File;
 import org.nova.backend.board.common.domain.model.valueobject.PostType;
+import org.nova.backend.board.util.FileCacheKeyConstants;
+import org.nova.backend.board.util.FileStorageUtil;
 import org.nova.backend.board.util.FileUtil;
+import org.nova.backend.board.util.ImageOptimizerUtil;
+import org.nova.backend.board.util.ImageOptimizerUtil.ImageCompressResult;
 import org.nova.backend.member.adapter.repository.MemberRepository;
+import org.nova.backend.member.domain.exception.MemberDomainException;
+import org.nova.backend.shared.constants.FilePathConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -126,12 +129,12 @@ public class FileService implements FileUseCase {
         String storagePath = getStoragePath();
 
         MultipartFile firstFile = files.getFirst();
-        FileResponse firstFileResponse = processFileUpload(firstFile, storagePath, postType, true);
+        FileResponse firstFileResponse = processFileUpload(firstFile, storagePath, postType);
 
         List<CompletableFuture<FileResponse>> futures = files.stream()
                 .skip(1)
                 .map(file -> CompletableFuture.supplyAsync(() ->
-                        processFileUpload(file, storagePath, postType, false), executor))
+                        processFileUpload(file, storagePath, postType), executor))
                 .toList();
 
         List<FileResponse> result = futures.stream()
@@ -150,8 +153,7 @@ public class FileService implements FileUseCase {
     private FileResponse processFileUpload(
             MultipartFile file,
             String storagePath,
-            PostType postType,
-            boolean isSynchronous
+            PostType postType
     ) {
         String originalFileName = file.getOriginalFilename();
         String extension = FileUtil.getFileExtension(originalFileName);
@@ -165,14 +167,10 @@ public class FileService implements FileUseCase {
         savedFile = filePersistencePort.save(savedFile);
 
         if (postType == PostType.PICTURES) {
+            copyFileToPublic(savedFilePath, storagePath, fileId, extension);
             redisTemplate.opsForValue().set("upload:" + fileId, "uploading");
-
-            if (isSynchronous) {
-                compressImageSync(fileId, savedFilePath, storagePath, extension);
-            } else {
-                CompletableFuture.runAsync(() ->
-                        compressImageAsync(fileId, savedFilePath, storagePath, extension), executor);
-            }
+            CompletableFuture.runAsync(() ->
+                    compressImageAsync(fileId, savedFilePath, storagePath, extension), executor);
         }
 
         return new FileResponse(
@@ -180,6 +178,24 @@ public class FileService implements FileUseCase {
                 savedFile.getOriginalFilename(),
                 "/api/v1/files/" + savedFile.getId() + "/download"
         );
+    }
+
+    private void copyFileToPublic(
+            String sourcePath,
+            String storagePath,
+            UUID fileId,
+            String extension
+    ) {
+        Path source = Paths.get(sourcePath);
+        Path publicDir = Paths.get(storagePath, FilePathConstants.PUBLIC_FOLDER);
+
+        try {
+            Files.createDirectories(publicDir);
+            Path target = publicDir.resolve(fileId + "." + extension);
+            Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new FileDomainException("공개용 이미지 복사 중 오류가 발생했습니다.", e);
+        }
     }
 
     private void compressImageAsync(
@@ -197,34 +213,17 @@ public class FileService implements FileUseCase {
             Path protectedPath = Paths.get(originalFilePath);
             Path publicDir = Paths.get(storagePath, FilePathConstants.PUBLIC_FOLDER);
 
-            ImageOptimizerUtil.compressToOriginalExtension(protectedPath, publicDir, fileId, extension);
+            ImageCompressResult compressResult = ImageOptimizerUtil.compressToOriginalExtension(protectedPath, publicDir, fileId, extension);
+
+            redisTemplate.opsForValue().set(
+                    FileCacheKeyConstants.imageMetaKey(fileId),
+                    compressResult.originalWidth() + "x" + compressResult.originalHeight()
+            );
 
             redisTemplate.opsForValue().set("upload:" + fileId, "done");
             logger.info("[압축 완료] fileId={}", fileId);
         } catch (Exception e) {
             logger.error("이미지 압축 중 오류", e);
-            redisTemplate.opsForValue().set("upload:" + fileId, "error");
-        }
-    }
-
-    private void compressImageSync(
-            UUID fileId,
-            String originalFilePath,
-            String storagePath,
-            String extension
-    ) {
-        try {
-            redisTemplate.opsForValue().set("upload:" + fileId, "compressing");
-
-            Path protectedPath = Paths.get(originalFilePath);
-            Path publicDir = Paths.get(storagePath, FilePathConstants.PUBLIC_FOLDER);
-
-            ImageOptimizerUtil.compressToOriginalExtension(protectedPath, publicDir, fileId, extension);
-
-            redisTemplate.opsForValue().set("upload:" + fileId, "done");
-            logger.info("[동기 압축 완료] 썸네일 fileId={}", fileId);
-        } catch (Exception e) {
-            logger.error("동기 이미지 압축 중 오류", e);
             redisTemplate.opsForValue().set("upload:" + fileId, "error");
         }
     }

--- a/src/main/java/org/nova/backend/board/util/FileCacheKeyConstants.java
+++ b/src/main/java/org/nova/backend/board/util/FileCacheKeyConstants.java
@@ -1,0 +1,15 @@
+package org.nova.backend.board.util;
+
+import java.util.UUID;
+
+public final class FileCacheKeyConstants {
+    public static final String IMAGE_META_PREFIX = "image:meta:";
+
+    private FileCacheKeyConstants() {
+        throw new UnsupportedOperationException("상수 클래스는 인스턴스화할 수 없습니다.");
+    }
+
+    public static String imageMetaKey(UUID fileId) {
+        return IMAGE_META_PREFIX + fileId;
+    }
+}

--- a/src/main/java/org/nova/backend/board/util/ImageOptimizerUtil.java
+++ b/src/main/java/org/nova/backend/board/util/ImageOptimizerUtil.java
@@ -7,16 +7,16 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.io.OutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 import javax.imageio.ImageIO;
-import java.nio.file.Files;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.awt.image.AffineTransformOp;
 import org.nova.backend.board.common.domain.exception.FileDomainException;
+import java.awt.image.AffineTransformOp;
 
 public class ImageOptimizerUtil {
     private static final Logger logger = LoggerFactory.getLogger(ImageOptimizerUtil.class);
@@ -30,14 +30,17 @@ public class ImageOptimizerUtil {
      * @param inputPath 원본 이미지 경로
      * @param outputDir 저장 디렉토리 (예: public)
      * @param uuid 고유 파일 이름 생성용 UUID
-     * @return 저장된 WebP 파일 경로
+     * @return 저장된 WebP 파일 경로와 원본 이미지 크기
      */
-    public static Path compressToOriginalExtension(
+    public static ImageCompressResult compressToOriginalExtension(
             Path inputPath,
             Path outputDir,
             UUID uuid,
             String originalExtension
     ) {
+        Path outputPath = outputDir.resolve(uuid + "." + originalExtension);
+        Path tempOutputPath = outputDir.resolve(uuid + "." + originalExtension + ".tmp");
+
         try {
             BufferedImage originalImage = ImageIO.read(inputPath.toFile());
             if (originalImage == null) {
@@ -59,22 +62,29 @@ public class ImageOptimizerUtil {
                 Files.createDirectories(outputDir);
             }
 
-            Path outputPath = outputDir.resolve(uuid + "." + originalExtension);
-
-            try (OutputStream os = Files.newOutputStream(outputPath)) {
+            try (var os = Files.newOutputStream(tempOutputPath)) {
                 boolean written = ImageIO.write(compressedImage, originalExtension, os);
                 if (!written) {
                     throw new FileDomainException("압축 이미지 저장 실패 (확장자=" + originalExtension + "): " + outputPath);
                 }
             }
 
+            Files.move(tempOutputPath, outputPath, StandardCopyOption.REPLACE_EXISTING);
+
             logger.info("이미지 압축 저장 완료: {}", outputPath);
-            return outputPath;
+            return new ImageCompressResult(outputPath, originalImage.getWidth(), originalImage.getHeight());
         } catch (IOException e) {
-            logger.error("이미지 압축 중 오류", e);
             throw new FileDomainException("이미지 압축 실패", e);
+        } finally {
+            try {
+                Files.deleteIfExists(tempOutputPath);
+            } catch (IOException ex) {
+                logger.warn("압축 실패 후 임시 파일 삭제 실패: {}", tempOutputPath, ex);
+            }
         }
     }
+
+    public record ImageCompressResult(Path outputPath, int originalWidth, int originalHeight) {}
 
     public static BufferedImage applyExifOrientationFix(Path inputPath, BufferedImage image) {
         try {


### PR DESCRIPTION
이미지 파일 업로드 및 조회 로직의 성능과 안정성을 극대화하기 위해 Redis 캐싱을 도입하고, 
이미지 압축 및 썸네일 제공 방식을 비동기적으로 개선. 
이 변경을 통해 업로드 API 응답 시간을 단축하고, 이미지 메타데이터 조회 속도를 향상

- 이미지 압축 시 원본 가로·세로 정보를 Redis image:meta:{fileId}에 기록
- 조회 시 보호 경로를 매번 열지 않고 캐시된 크기 우선 사용, 없으면 1회 읽어 캐싱
- 사진 업로드 시 공개 폴더에 원본 복사본을 즉시 만들어 최초 썸네일 접근 속도 유지