### PR TITLE
refactor: 예외 처리 통일 및 비밀번호 초기화 로그 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### queryDSL files ###
 src/main/generated/
+/spec/*

--- a/src/main/java/org/nova/backend/auth/UnauthorizedException.java
+++ b/src/main/java/org/nova/backend/auth/UnauthorizedException.java
@@ -1,11 +1,24 @@
 package org.nova.backend.auth;
 
-public class UnauthorizedException extends RuntimeException {
+import org.nova.backend.shared.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends CustomException {
     public UnauthorizedException(String message) {
-        super(message);
+        super(message, HttpStatus.FORBIDDEN);
     }
 
     public UnauthorizedException(String message, Throwable cause) {
-        super(message, cause);
+        super(message, HttpStatus.FORBIDDEN);
+        initCause(cause);
+    }
+
+    public UnauthorizedException(String message, HttpStatus status) {
+        super(message, status);
+    }
+
+    public UnauthorizedException(String message, HttpStatus status, Throwable cause) {
+        super(message, status);
+        initCause(cause);
     }
 }

--- a/src/main/java/org/nova/backend/auth/adapter/web/PasswordResetController.java
+++ b/src/main/java/org/nova/backend/auth/adapter/web/PasswordResetController.java
@@ -2,6 +2,7 @@ package org.nova.backend.auth.adapter.web;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.nova.backend.auth.application.dto.request.PasswordResetRequest;
 import org.nova.backend.auth.application.service.PasswordResetService;
 import org.nova.backend.shared.model.ApiResponse;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Login API", description = "로그인 관련 API 목록")
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 public class PasswordResetController {
@@ -22,7 +24,9 @@ public class PasswordResetController {
     @PostMapping("/reset-password")
     @AuthApiDocument.PasswordResetApiDoc
     public ResponseEntity<ApiResponse<String>> resetPassword(@RequestBody PasswordResetRequest request) {
+        log.info("비밀번호 초기화 요청 수신");
         passwordResetService.resetPassword(request);
+        log.info("비밀번호 초기화 요청 처리 완료");
         return ResponseEntity.ok(ApiResponse.success("임시 비밀번호가 이메일로 전송되었습니다."));
     }
 }

--- a/src/main/java/org/nova/backend/auth/application/service/PasswordResetService.java
+++ b/src/main/java/org/nova/backend/auth/application/service/PasswordResetService.java
@@ -21,14 +21,23 @@ public class PasswordResetService {
     private final EmailSendService emailSendService;
 
     public void resetPassword(PasswordResetRequest request) {
-        Member member = memberRepository.findByNameAndEmail(request.getName(), request.getEmail())
-                .orElseThrow(() -> new MemberDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        log.info("비밀번호 초기화 시작");
+        try {
+            Member member = memberRepository.findByNameAndEmail(request.getName(), request.getEmail())
+                    .orElseThrow(() -> new MemberDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+            log.info("회원 조회 성공 - 사용자 ID: {}", member.getId());
 
-        String tempPassword = generateTempPassword();
-        member.resetPasswordWithTemp(passwordEncoder.encode(tempPassword));
-        memberRepository.save(member);
+            String tempPassword = generateTempPassword();
+            member.resetPasswordWithTemp(passwordEncoder.encode(tempPassword));
+            memberRepository.save(member);
+            log.info("임시 비밀번호 저장 완료 - 사용자 ID: {}", member.getId());
 
-        emailSendService.sendTempPasswordEmail(member.getEmail(), tempPassword);
+            emailSendService.sendTempPasswordEmail(member.getId(), member.getEmail(), tempPassword);
+            log.info("임시 비밀번호 메일 발송 완료 - 사용자 ID: {}", member.getId());
+        } catch (Exception e) {
+            log.error("비밀번호 초기화 중 에러 발생", e);
+            throw e;
+        }
     }
 
     private String generateTempPassword() {

--- a/src/main/java/org/nova/backend/board/clubArchive/application/service/JokboPostService.java
+++ b/src/main/java/org/nova/backend/board/clubArchive/application/service/JokboPostService.java
@@ -81,7 +81,7 @@ public class JokboPostService implements JokboPostUseCase {
         Board board = boardUseCase.getBoardById(boardId);
 
         if (board.getCategory() != BoardCategory.CLUB_ARCHIVE) {
-            throw new BoardDomainException( MSG_INVALID_CATEGORY);
+            throw new BoardDomainException(MSG_INVALID_CATEGORY, HttpStatus.BAD_REQUEST);
         }
 
         Post post =  new Post(
@@ -131,13 +131,13 @@ public class JokboPostService implements JokboPostUseCase {
         ValidationUtil.requireNonBlank(request.getContent(), "내용");
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         JokboPost jokboPost = jokboPostPersistencePort.findByPost(post)
-                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         if (!post.getMember().getId().equals(memberId)) {
-            throw new BoardDomainException(MSG_NO_UPDATE_PERMISSION);
+            throw new BoardDomainException(MSG_NO_UPDATE_PERMISSION, HttpStatus.FORBIDDEN);
         }
 
         if (request.getDeleteFileIds() != null && !request.getDeleteFileIds().isEmpty()) {
@@ -172,17 +172,17 @@ public class JokboPostService implements JokboPostUseCase {
             UUID memberId
     ) {
         Post post = postRepository.findByBoardIdAndPostId(boardId, postId)
-                .orElseThrow(() -> new BoardDomainException(MSG_POST_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_POST_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         JokboPost jokboPost = jokboPostPersistencePort.findByPost(post)
-                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException(MSG_NOT_FOUND_USER));
+                .orElseThrow(() -> new BoardDomainException(MSG_NOT_FOUND_USER, HttpStatus.NOT_FOUND));
 
         if (!post.getMember().getId().equals(memberId) && member.getRole() != Role.ADMINISTRATOR) {
             logger.warn("사용자 {}가 게시글 {}를 삭제하려 했으나 권한이 없습니다.", memberId, postId);
-            throw new BoardDomainException(MSG_NO_DELETE_PERMISSION);
+            throw new BoardDomainException(MSG_NO_DELETE_PERMISSION, HttpStatus.FORBIDDEN);
         }
 
         List<UUID> fileIds = jokboPost.getPost().getFiles().stream().map(File::getId).toList();
@@ -204,10 +204,10 @@ public class JokboPostService implements JokboPostUseCase {
     ) {
         basePostPersistencePort.increaseViewCount(postId);
         Post post = postRepository.findByBoardIdAndPostId(boardId, postId)
-                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         JokboPost jokboPost = jokboPostPersistencePort.findByPostId(postId)
-                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_INFO_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_JOKBO_INFO_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         UUID memberId = securityUtil.getCurrentMemberIdOrNull();
         boolean isLiked = (memberId != null) && postLikePersistencePort.findByPostIdAndMemberId(postId, memberId).isPresent();

--- a/src/main/java/org/nova/backend/board/clubArchive/application/service/PicturePostService.java
+++ b/src/main/java/org/nova/backend/board/clubArchive/application/service/PicturePostService.java
@@ -63,7 +63,7 @@ public class PicturePostService implements PicturePostUseCase {
         Board board = boardUseCase.getBoardById(boardId);
 
         if (board.getCategory() != BoardCategory.CLUB_ARCHIVE) {
-            throw new BoardDomainException("사진 게시글은 'CLUB_ARCHIVE' 게시판에서만 작성할 수 있습니다.");
+            throw new BoardDomainException("사진 게시글은 'CLUB_ARCHIVE' 게시판에서만 작성할 수 있습니다.", HttpStatus.BAD_REQUEST);
         }
 
         Post post = new Post(
@@ -118,7 +118,7 @@ public class PicturePostService implements PicturePostUseCase {
                 .orElseThrow(() -> new PictureDomainException("게시글을 찾을 수 없습니다. ID: " + postId, HttpStatus.NOT_FOUND));
 
         if (!post.getBoard().getId().equals(boardId)) {
-            throw new BoardDomainException("잘못된 게시판 ID입니다.");
+            throw new BoardDomainException("잘못된 게시판 ID입니다.", HttpStatus.NOT_FOUND);
         }
 
         if (!post.getMember().getId().equals(memberId)) {
@@ -154,10 +154,10 @@ public class PicturePostService implements PicturePostUseCase {
             UUID memberId
     ) {
         Post post = basePostPersistencePort.findById(postId)
-                .orElseThrow(() -> new BoardDomainException("게시글을 찾을 수 없습니다. ID: " + postId));
+                .orElseThrow(() -> new BoardDomainException("게시글을 찾을 수 없습니다. ID: " + postId, HttpStatus.NOT_FOUND));
 
         if (!post.getBoard().getId().equals(boardId)) {
-            throw new BoardDomainException("잘못된 게시판 ID입니다.");
+            throw new BoardDomainException("잘못된 게시판 ID입니다.", HttpStatus.NOT_FOUND);
         }
 
         Member member = memberRepository.findById(memberId)
@@ -184,7 +184,7 @@ public class PicturePostService implements PicturePostUseCase {
     ) {
         basePostPersistencePort.increaseViewCount(postId);
         Post post = basePostPersistencePort.findByBoardIdAndPostId(boardId, postId)
-                .orElseThrow(() -> new BoardDomainException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardDomainException("게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         UUID memberId = securityUtil.getOptionalCurrentMemberId().orElse(null);
         boolean isLiked = (memberId != null) && postLikePersistencePort.findByPostIdAndMemberId(postId, memberId).isPresent();

--- a/src/main/java/org/nova/backend/board/common/application/service/BasePostService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/BasePostService.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -82,7 +83,7 @@ public class BasePostService implements BasePostUseCase {
         ValidationUtil.requireNonBlank(request.getContent(), "내용");
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException(MSG_USER_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_USER_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         if (request.getPostType() == PostType.NOTICE && !boardSecurityChecker.isAdminOrPresident(member)) {
             throw new UnauthorizedException(MSG_UNAUTHORIZED_NOTICE);
@@ -94,7 +95,8 @@ public class BasePostService implements BasePostUseCase {
             throw new BoardDomainException(
                     String.format("게시판 [%s]에는 [%s] 타입의 게시글을 저장할 수 없습니다.",
                             board.getCategory().getDisplayName(),
-                            request.getPostType().getDisplayName())
+                            request.getPostType().getDisplayName()),
+                    HttpStatus.BAD_REQUEST
             );
         }
 
@@ -221,7 +223,7 @@ public class BasePostService implements BasePostUseCase {
     ) {
         basePostPersistencePort.increaseViewCount(postId);
         Post post = basePostPersistencePort.findByBoardIdAndPostId(boardId, postId)
-                .orElseThrow(() -> new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         UUID memberId = securityUtil.getOptionalCurrentMemberId().orElse(null);
         boolean isLiked = (memberId != null) && postLikePersistencePort.findByPostIdAndMemberId(postId, memberId).isPresent();
@@ -239,13 +241,13 @@ public class BasePostService implements BasePostUseCase {
             UUID memberId
     ) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException(MSG_USER_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_USER_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         Post post = basePostPersistencePort.findById(postId)
-                .orElseThrow(() -> new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         if (postLikePersistencePort.findByPostIdAndMemberId(postId, memberId).isPresent()) {
-            throw new BoardDomainException(MSG_POST_LIKE_DUPLICATE);
+            throw new BoardDomainException(MSG_POST_LIKE_DUPLICATE, HttpStatus.CONFLICT);
         }
 
         postLikePersistencePort.save(new PostLike(post, member));
@@ -274,7 +276,7 @@ public class BasePostService implements BasePostUseCase {
             UUID memberId
     ) {
         if (postLikePersistencePort.findByPostIdAndMemberId(postId, memberId).isEmpty()) {
-            throw new BoardDomainException(MSG_POST_LIKE_NOT_FOUND);
+            throw new BoardDomainException(MSG_POST_LIKE_NOT_FOUND, HttpStatus.NOT_FOUND);
         }
 
         postLikePersistencePort.deleteByPostIdAndMemberId(postId, memberId);
@@ -302,14 +304,14 @@ public class BasePostService implements BasePostUseCase {
         ValidationUtil.requireNonBlank(request.getContent(), "내용");
 
         Post post = basePostPersistencePort.findById(postId)
-                .orElseThrow(() -> new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         if (!post.getBoard().getId().equals(boardId)) {
-            throw new BoardDomainException(BoardErrorMessages.INVALID_BOARD_ID);
+            throw new BoardDomainException(BoardErrorMessages.INVALID_BOARD_ID, HttpStatus.NOT_FOUND);
         }
 
         if (!post.getMember().getId().equals(memberId)) {
-            throw new BoardDomainException(BoardErrorMessages.NO_AUTHORITY);
+            throw new BoardDomainException(BoardErrorMessages.NO_AUTHORITY, HttpStatus.FORBIDDEN);
         }
 
         if (request.getDeleteFileIds() != null && !request.getDeleteFileIds().isEmpty()) {
@@ -348,19 +350,19 @@ public class BasePostService implements BasePostUseCase {
         Post post = basePostPersistencePort.findById(postId)
                 .orElseThrow(() -> {
                     logger.error("삭제 요청한 게시글이 존재하지 않습니다. ID: {}", postId);
-                    return new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND);
+                    return new BoardDomainException(BoardErrorMessages.POST_NOT_FOUND, HttpStatus.NOT_FOUND);
                 });
 
         if (!post.getBoard().getId().equals(boardId)) {
-            throw new BoardDomainException(BoardErrorMessages.INVALID_BOARD_ID);
+            throw new BoardDomainException(BoardErrorMessages.INVALID_BOARD_ID, HttpStatus.NOT_FOUND);
         }
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException(MSG_USER_NOT_FOUND));
+                .orElseThrow(() -> new BoardDomainException(MSG_USER_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         if (!post.getMember().getId().equals(memberId) && member.getRole() != Role.ADMINISTRATOR) {
             logger.warn("사용자 {}가 게시글 {}를 삭제하려 했으나 권한이 없습니다.", memberId, postId);
-            throw new BoardDomainException(BoardErrorMessages.NO_AUTHORITY);
+            throw new BoardDomainException(BoardErrorMessages.NO_AUTHORITY, HttpStatus.FORBIDDEN);
         }
 
         List<UUID> fileIds = post.getFiles().stream().map(File::getId).toList();

--- a/src/main/java/org/nova/backend/board/common/application/service/BoardService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/BoardService.java
@@ -10,6 +10,7 @@ import org.nova.backend.board.common.domain.exception.BoardDomainException;
 import org.nova.backend.board.common.domain.model.entity.Board;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -39,7 +40,7 @@ public class BoardService implements BoardUseCase {
         return boardPersistencePort.findById(boardId)
                 .orElseThrow(() -> {
                     logger.warn("게시판을 찾을 수 없습니다. ID: {}", boardId);
-                    return new BoardDomainException("게시판을 찾을 수 없습니다. ID: " + boardId);
+                    return new BoardDomainException("게시판을 찾을 수 없습니다. ID: " + boardId, HttpStatus.NOT_FOUND);
                 });
     }
 }

--- a/src/main/java/org/nova/backend/board/common/application/service/CommentService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/CommentService.java
@@ -22,6 +22,7 @@ import org.nova.backend.member.domain.model.entity.Member;
 import org.nova.backend.member.domain.model.valueobject.Role;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -46,10 +47,10 @@ public class CommentService implements CommentUseCase {
             UUID memberId
     ) {
         Comment comment = commentPersistencePort.findById(commentId)
-                .orElseThrow(() -> new CommentDomainException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CommentDomainException("댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         if (!comment.getMember().getId().equals(memberId)) {
-            throw new CommentDomainException("자신의 댓글만 수정할 수 있습니다.");
+            throw new CommentDomainException("자신의 댓글만 수정할 수 있습니다.", HttpStatus.FORBIDDEN);
         }
 
         comment.updateContent(request.getContent());
@@ -68,14 +69,14 @@ public class CommentService implements CommentUseCase {
             UUID memberId
     ) {
         Comment comment = commentPersistencePort.findById(commentId)
-                .orElseThrow(() -> new CommentDomainException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CommentDomainException("댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         if (!comment.getMember().getId().equals(memberId) && member.getRole() != Role.ADMINISTRATOR) {
             logger.warn("사용자 {}가 댓글 {}를 삭제하려 했으나 권한이 없습니다.", memberId, commentId);
-            throw new CommentDomainException("댓글 삭제 권한이 없습니다.");
+            throw new CommentDomainException("댓글 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN);
         }
 
         Post post = comment.getPost();
@@ -102,15 +103,15 @@ public class CommentService implements CommentUseCase {
             UUID memberId
     ) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         Post post = basePostPersistencePort.findById(postId)
-                .orElseThrow(() -> new BoardDomainException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardDomainException("게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         Comment parentComment = null;
         if (request.getParentCommentId() != null) {
             parentComment = commentPersistencePort.findById(request.getParentCommentId())
-                    .orElseThrow(() -> new CommentDomainException("대댓글을 찾을 수 없습니다."));
+                    .orElseThrow(() -> new CommentDomainException("대댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         }
 
         Comment comment = commentMapper.toEntity(request, post, member, parentComment);

--- a/src/main/java/org/nova/backend/board/common/application/service/FileService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/FileService.java
@@ -99,7 +99,7 @@ public class FileService implements FileUseCase {
     @Transactional(readOnly = true)
     public Optional<File> findFileById(UUID fileId) {
         return Optional.ofNullable(filePersistencePort.findFileById(fileId)
-                .orElseThrow(() -> new FileDomainException("파일을 찾을 수 없습니다. ID: " + fileId)));
+                .orElseThrow(() -> new FileDomainException("파일을 찾을 수 없습니다. ID: " + fileId, HttpStatus.NOT_FOUND)));
     }
 
     /**
@@ -194,7 +194,7 @@ public class FileService implements FileUseCase {
             Path target = publicDir.resolve(fileId + "." + extension);
             Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new FileDomainException("공개용 이미지 복사 중 오류가 발생했습니다.", e);
+            throw new FileDomainException("공개용 이미지 복사 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -245,13 +245,13 @@ public class FileService implements FileUseCase {
             UUID memberId
     ) {
         File file = filePersistencePort.findFileById(fileId)
-                .orElseThrow(() -> new FileDomainException("파일을 찾을 수 없습니다."));
+                .orElseThrow(() -> new FileDomainException("파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         if (file.getPost() != null) {
             UUID postOwnerId = file.getPost().getMember().getId();
 
             if (!postOwnerId.equals(memberId)) {
-                throw new FileDomainException("게시글 작성자만 파일을 삭제할 수 있습니다.");
+                throw new FileDomainException("게시글 작성자만 파일을 삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
             }
         }
 
@@ -278,7 +278,7 @@ public class FileService implements FileUseCase {
                 .orElseThrow(() -> new MemberDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         File file = filePersistencePort.findFileById(fileId)
-                .orElseThrow(() -> new FileDomainException("파일을 찾을 수 없습니다."));
+                .orElseThrow(() -> new FileDomainException("파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         processFileDownload(file, response);
         updateDownloadCount(file);
@@ -290,7 +290,7 @@ public class FileService implements FileUseCase {
     private void processFileDownload(File file, HttpServletResponse response) {
         Path filePath = Paths.get(file.getFilePath());
         if (!Files.exists(filePath)) {
-            throw new FileDomainException("파일이 존재하지 않습니다.");
+            throw new FileDomainException("파일이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
         }
 
         String encodedFileName = FileUtil.encodeFileName(file.getOriginalFilename());
@@ -299,7 +299,7 @@ public class FileService implements FileUseCase {
             long fileSize = Files.size(filePath);
             response.setContentLengthLong(fileSize);
         } catch (IOException e) {
-            throw new FileDomainException("파일 크기 조회 중 오류 발생", e);
+            throw new FileDomainException("파일 크기 조회 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
 
         response.setContentType(FileUtil.getDefaultContentType());
@@ -309,7 +309,7 @@ public class FileService implements FileUseCase {
             StreamUtils.copy(inputStream, response.getOutputStream());
             response.flushBuffer();
         } catch (IOException e) {
-            throw new FileDomainException("파일 다운로드 중 오류 발생", e);
+            throw new FileDomainException("파일 다운로드 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 

--- a/src/main/java/org/nova/backend/board/common/domain/exception/BoardDomainException.java
+++ b/src/main/java/org/nova/backend/board/common/domain/exception/BoardDomainException.java
@@ -1,11 +1,15 @@
 package org.nova.backend.board.common.domain.exception;
 
-public class BoardDomainException extends RuntimeException {
-    public BoardDomainException(String message) {
-        super(message);
+import org.nova.backend.shared.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class BoardDomainException extends CustomException {
+    public BoardDomainException(String message, HttpStatus status) {
+        super(message, status);
     }
 
-    public BoardDomainException(String message, Throwable cause) {
-        super(message, cause);
+    public BoardDomainException(String message, HttpStatus status, Throwable cause) {
+        super(message, status);
+        initCause(cause);
     }
 }

--- a/src/main/java/org/nova/backend/board/common/domain/exception/CommentDomainException.java
+++ b/src/main/java/org/nova/backend/board/common/domain/exception/CommentDomainException.java
@@ -1,11 +1,15 @@
 package org.nova.backend.board.common.domain.exception;
 
-public class CommentDomainException extends RuntimeException {
-    public CommentDomainException(String message) {
-        super(message);
+import org.nova.backend.shared.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class CommentDomainException extends CustomException {
+    public CommentDomainException(String message, HttpStatus status) {
+        super(message, status);
     }
 
-    public CommentDomainException(String message, Throwable cause) {
-        super(message, cause);
+    public CommentDomainException(String message, HttpStatus status, Throwable cause) {
+        super(message, status);
+        initCause(cause);
     }
 }

--- a/src/main/java/org/nova/backend/board/common/domain/exception/FileDomainException.java
+++ b/src/main/java/org/nova/backend/board/common/domain/exception/FileDomainException.java
@@ -1,11 +1,15 @@
 package org.nova.backend.board.common.domain.exception;
 
-public class FileDomainException extends RuntimeException {
-    public FileDomainException(String message) {
-        super(message);
+import org.nova.backend.shared.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class FileDomainException extends CustomException {
+    public FileDomainException(String message, HttpStatus status) {
+        super(message, status);
     }
 
-    public FileDomainException(String message, Throwable cause) {
-        super(message, cause);
+    public FileDomainException(String message, HttpStatus status, Throwable cause) {
+        super(message, status);
+        initCause(cause);
     }
 }

--- a/src/main/java/org/nova/backend/board/common/domain/model/valueobject/Content.java
+++ b/src/main/java/org/nova/backend/board/common/domain/model/valueobject/Content.java
@@ -3,6 +3,7 @@ package org.nova.backend.board.common.domain.model.valueobject;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import org.nova.backend.board.common.domain.exception.BoardDomainException;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Embeddable
@@ -15,10 +16,10 @@ public final class Content {
 
     public Content(String content){
         if (content == null || content.trim().isEmpty()) {
-            throw new BoardDomainException("내용은 비어 있을 수 없습니다.");
+            throw new BoardDomainException("내용은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
         if (content.length() > 5000) {
-            throw new BoardDomainException("내용은 5000자를 초과할 수 없습니다.");
+            throw new BoardDomainException("내용은 5000자를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
         this.content = content;
     }

--- a/src/main/java/org/nova/backend/board/common/domain/model/valueobject/Title.java
+++ b/src/main/java/org/nova/backend/board/common/domain/model/valueobject/Title.java
@@ -3,6 +3,7 @@ package org.nova.backend.board.common.domain.model.valueobject;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import org.nova.backend.board.common.domain.exception.BoardDomainException;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Embeddable
@@ -15,10 +16,10 @@ public final class Title {
 
     public Title(String title){
         if(title == null || title.trim().isEmpty()){
-            throw  new BoardDomainException("제목은 비어 있을 수 없습니다.");
+            throw  new BoardDomainException("제목은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
         if(title.length() > 255) {
-            throw new BoardDomainException("제목은 255자를 초과할 수 없습니다.");
+            throw new BoardDomainException("제목은 255자를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
         this.title = title;
     }

--- a/src/main/java/org/nova/backend/board/suggestion/application/service/SuggestionFileService.java
+++ b/src/main/java/org/nova/backend/board/suggestion/application/service/SuggestionFileService.java
@@ -118,7 +118,7 @@ public class SuggestionFileService implements SuggestionFileUseCase {
             UUID memberId
     ) {
         memberRepository.findById(memberId)
-                .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         SuggestionFile file = filePersistencePort.findFileById(fileId)
                 .orElseThrow(() -> new SuggestionFileDomainException("파일을 찾을 수 없습니다.",HttpStatus.NOT_FOUND));

--- a/src/main/java/org/nova/backend/board/suggestion/application/service/SuggestionPostService.java
+++ b/src/main/java/org/nova/backend/board/suggestion/application/service/SuggestionPostService.java
@@ -58,7 +58,7 @@ public class SuggestionPostService implements SuggestionPostUseCase {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
                     logger.error("건의 게시글 생성 실패 - 사용자 없음 ID: {}", memberId);
-                    return new BoardDomainException("사용자를 찾을 수 없습니다.");
+                    return new BoardDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
                 });
 
         SuggestionPost post = postMapper.toEntity(request, member);
@@ -114,7 +114,7 @@ public class SuggestionPostService implements SuggestionPostUseCase {
             }
         } else {
             Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다."));
+                    .orElseThrow(() -> new BoardDomainException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
             if (member.getRole() == Role.ADMINISTRATOR && !post.isAdminRead()) {
                 logger.info("관리자가 게시글을 읽음 - 게시글 ID: {}", postId);
@@ -151,11 +151,11 @@ public class SuggestionPostService implements SuggestionPostUseCase {
                 });
 
         Member admin = memberRepository.findById(adminId)
-                .orElseThrow(() -> new BoardDomainException("관리자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardDomainException("관리자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         if (admin.getRole() != Role.ADMINISTRATOR) {
             logger.warn("사용자 {}가 건의 게시글 {}에 답변을 작성하려 했으나 권한이 없습니다.", adminId, postId);
-            throw new BoardDomainException("건의 게시글에 답변을 작성할 권한이 없습니다.");
+            throw new BoardDomainException("건의 게시글에 답변을 작성할 권한이 없습니다.", HttpStatus.FORBIDDEN);
         }
 
         post.addAdminReply(request.getReply());

--- a/src/main/java/org/nova/backend/board/util/FileStorageUtil.java
+++ b/src/main/java/org/nova/backend/board/util/FileStorageUtil.java
@@ -5,6 +5,7 @@ import org.nova.backend.board.common.domain.exception.FileDomainException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -39,7 +40,7 @@ public class FileStorageUtil {
 
             Path targetPath = fileDir.resolve(uuid + "." + extension);
             if (!targetPath.toAbsolutePath().startsWith(fileDir.toAbsolutePath())) {
-                throw new FileDomainException("잘못된 파일 경로가 탐지되었습니다.");
+                throw new FileDomainException("잘못된 파일 경로가 탐지되었습니다.", HttpStatus.BAD_REQUEST);
             }
 
             file.transferTo(targetPath.toFile());
@@ -47,7 +48,7 @@ public class FileStorageUtil {
 
         } catch (IOException e) {
             logger.error("파일 저장 중 오류 발생: {}", file.getOriginalFilename(), e);
-            throw new FileDomainException("파일 저장 중 오류 발생", e);
+            throw new FileDomainException("파일 저장 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -61,7 +62,7 @@ public class FileStorageUtil {
             logger.info("파일 삭제 성공: {}", filePath);
         } catch (IOException e) {
             logger.error("파일 삭제 실패: {}", filePath, e);
-            throw new FileDomainException("파일 삭제 중 오류 발생", e);
+            throw new FileDomainException("파일 삭제 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -75,7 +76,7 @@ public class FileStorageUtil {
     ) {
         Path path = Paths.get(filePath);
         if (!Files.exists(path)) {
-            throw new FileDomainException("파일이 존재하지 않습니다.");
+            throw new FileDomainException("파일이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
         }
 
         response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
@@ -85,7 +86,7 @@ public class FileStorageUtil {
             StreamUtils.copy(inputStream, response.getOutputStream());
             response.flushBuffer();
         } catch (IOException e) {
-            throw new FileDomainException("파일 다운로드 중 오류 발생");
+            throw new FileDomainException("파일 다운로드 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/org/nova/backend/board/util/FileUtil.java
+++ b/src/main/java/org/nova/backend/board/util/FileUtil.java
@@ -4,6 +4,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.nova.backend.board.common.domain.exception.FileDomainException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -23,10 +24,10 @@ public class FileUtil {
      */
     public static void validateFileList(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
-            throw new FileDomainException("업로드할 파일이 없습니다.");
+            throw new FileDomainException("업로드할 파일이 없습니다.", HttpStatus.BAD_REQUEST);
         }
         if (files.size() > MAX_FILE_COUNT) {
-            throw new FileDomainException("첨부파일은 최대 " + MAX_FILE_COUNT + "개까지 가능합니다.");
+            throw new FileDomainException("첨부파일은 최대 " + MAX_FILE_COUNT + "개까지 가능합니다.", HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -36,7 +37,7 @@ public class FileUtil {
      */
     public static void validateFileSize(MultipartFile file) {
         if (file.getSize() > MAX_FILE_SIZE) {
-            throw new FileDomainException("파일 크기가 너무 큽니다. 최대 허용 크기: " + (MAX_FILE_SIZE / (1024L * 1024L)) + "MB");
+            throw new FileDomainException("파일 크기가 너무 큽니다. 최대 허용 크기: " + (MAX_FILE_SIZE / (1024L * 1024L)) + "MB", HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -46,12 +47,12 @@ public class FileUtil {
     public static void validateFileExtension(MultipartFile file) {
         String fileName = file.getOriginalFilename();
         if (fileName == null || fileName.isBlank()) {
-            throw new FileDomainException("파일 이름이 없습니다.");
+            throw new FileDomainException("파일 이름이 없습니다.", HttpStatus.BAD_REQUEST);
         }
 
         String extension = getFileExtension(fileName);
         if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
-            throw new FileDomainException("허용되지 않은 파일 확장자입니다: " + extension);
+            throw new FileDomainException("허용되지 않은 파일 확장자입니다: " + extension, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -71,7 +72,7 @@ public class FileUtil {
      */
     public static String encodeFileName(String fileName) {
         if (fileName == null || fileName.isBlank()) {
-            throw new FileDomainException("파일 이름이 없습니다.");
+            throw new FileDomainException("파일 이름이 없습니다.", HttpStatus.BAD_REQUEST);
         }
         return URLEncoder.encode(fileName, StandardCharsets.UTF_8)
                 .replace("+", "%20");
@@ -112,7 +113,7 @@ public class FileUtil {
      */
     public static void validateImageFile(MultipartFile file) {
         if (!isImageFile(file)) {
-            throw new FileDomainException("미리보기가 가능한 이미지 파일만 업로드할 수 있습니다. (지원 형식: JPG, JPEG, PNG, GIF, BMP, WEBP)");
+            throw new FileDomainException("미리보기가 가능한 이미지 파일만 업로드할 수 있습니다. (지원 형식: JPG, JPEG, PNG, GIF, BMP, WEBP)", HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/org/nova/backend/board/util/ImageOptimizerUtil.java
+++ b/src/main/java/org/nova/backend/board/util/ImageOptimizerUtil.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.nova.backend.board.common.domain.exception.FileDomainException;
 import java.awt.image.AffineTransformOp;
+import org.springframework.http.HttpStatus;
 
 public class ImageOptimizerUtil {
     private static final Logger logger = LoggerFactory.getLogger(ImageOptimizerUtil.class);
@@ -44,7 +45,7 @@ public class ImageOptimizerUtil {
         try {
             BufferedImage originalImage = ImageIO.read(inputPath.toFile());
             if (originalImage == null) {
-                throw new FileDomainException("이미지 로딩 실패: " + inputPath);
+                throw new FileDomainException("이미지 로딩 실패: " + inputPath, HttpStatus.BAD_REQUEST);
             }
 
             originalImage = applyExifOrientationFix(inputPath, originalImage);
@@ -65,7 +66,7 @@ public class ImageOptimizerUtil {
             try (var os = Files.newOutputStream(tempOutputPath)) {
                 boolean written = ImageIO.write(compressedImage, originalExtension, os);
                 if (!written) {
-                    throw new FileDomainException("압축 이미지 저장 실패 (확장자=" + originalExtension + "): " + outputPath);
+                    throw new FileDomainException("압축 이미지 저장 실패 (확장자=" + originalExtension + "): " + outputPath, HttpStatus.INTERNAL_SERVER_ERROR);
                 }
             }
 
@@ -74,7 +75,7 @@ public class ImageOptimizerUtil {
             logger.info("이미지 압축 저장 완료: {}", outputPath);
             return new ImageCompressResult(outputPath, originalImage.getWidth(), originalImage.getHeight());
         } catch (IOException e) {
-            throw new FileDomainException("이미지 압축 실패", e);
+            throw new FileDomainException("이미지 압축 실패", HttpStatus.INTERNAL_SERVER_ERROR, e);
         } finally {
             try {
                 Files.deleteIfExists(tempOutputPath);

--- a/src/main/java/org/nova/backend/board/util/ValidationUtil.java
+++ b/src/main/java/org/nova/backend/board/util/ValidationUtil.java
@@ -1,6 +1,7 @@
 package org.nova.backend.board.util;
 
 import org.nova.backend.board.common.domain.exception.BoardDomainException;
+import org.springframework.http.HttpStatus;
 
 public class ValidationUtil {
 
@@ -13,7 +14,7 @@ public class ValidationUtil {
             String fieldName
     ) {
         if (value == null || value.trim().isEmpty()) {
-            throw new BoardDomainException(fieldName + "은 비어 있을 수 없습니다.");
+            throw new BoardDomainException(fieldName + "은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/org/nova/backend/email/application/service/EmailSendService.java
+++ b/src/main/java/org/nova/backend/email/application/service/EmailSendService.java
@@ -2,12 +2,15 @@ package org.nova.backend.email.application.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nova.backend.email.domain.exception.EmailException;
 import org.nova.backend.email.domain.model.EmailAuth;
+import org.nova.backend.shared.util.LogMaskingUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -30,6 +33,8 @@ public class EmailSendService {
      * @param emailAuth 수신 이메일 주소, 인증 코드
      */
     public void sendAuthCodeEmail(EmailAuth emailAuth) {
+        log.info("인증 코드 이메일 발송 시작 - 이메일: {}",
+                LogMaskingUtil.maskEmail(emailAuth.getEmail()));
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         MimeMessageHelper mimeMessageHelper;
 
@@ -44,9 +49,13 @@ public class EmailSendService {
             mimeMessageHelper.setText(emailBody.toString(), true);
 
             javaMailSender.send(mimeMessage);
+            log.info("인증 코드 이메일 발송 완료 - 이메일: {}",
+                    LogMaskingUtil.maskEmail(emailAuth.getEmail()));
 
-        } catch (MessagingException e) {
-            throw new EmailException("email send failed." + emailAuth.getEmail(), HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (MessagingException | MailException e) {
+            log.error("인증 코드 이메일 발송 실패 - 이메일: {}",
+                    LogMaskingUtil.maskEmail(emailAuth.getEmail()), e);
+            throw new EmailException("이메일 인증 메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -56,7 +65,8 @@ public class EmailSendService {
      * @param toEmail 수신자 이메일 주소
      * @param tempPassword 임시 비밀번호
      */
-    public void sendTempPasswordEmail(String toEmail, String tempPassword) {
+    public void sendTempPasswordEmail(UUID memberId, String toEmail, String tempPassword) {
+        log.info("임시 비밀번호 이메일 발송 시작 - 사용자 ID: {}", memberId);
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         MimeMessageHelper mimeMessageHelper;
 
@@ -71,9 +81,11 @@ public class EmailSendService {
             mimeMessageHelper.setText(emailBody.toString(), true);
 
             javaMailSender.send(mimeMessage);
+            log.info("임시 비밀번호 이메일 발송 완료 - 사용자 ID: {}", memberId);
 
-        } catch (MessagingException e) {
-            throw new EmailException("임시 비밀번호 이메일 전송 실패: " + toEmail, HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (MessagingException | MailException e) {
+            log.error("임시 비밀번호 이메일 발송 실패 - 사용자 ID: {}", memberId, e);
+            throw new EmailException("임시 비밀번호 이메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/org/nova/backend/member/application/service/ProfilePhotoFileService.java
+++ b/src/main/java/org/nova/backend/member/application/service/ProfilePhotoFileService.java
@@ -46,7 +46,7 @@ public class ProfilePhotoFileService {
             MultipartFile profilePhoto
     ) {
         if (profilePhoto == null || profilePhoto.isEmpty()) {
-            throw new FileDomainException("업로드할 파일이 없습니다.");
+            throw new FileDomainException("업로드할 파일이 없습니다.", HttpStatus.BAD_REQUEST);
         }
 
         FileUtil.validateImageFile(profilePhoto);

--- a/src/main/java/org/nova/backend/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/nova/backend/shared/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.nova.backend.shared.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.nova.backend.shared.model.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,14 +8,16 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex) {
+        log.error("처리되지 않은 예외 발생", ex);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 오류가 발생했습니다: " + ex.getMessage(), 500));
+                .body(ApiResponse.error("서버 오류가 발생했습니다.", 500));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -26,6 +29,7 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse("Validation error");
 
+        log.warn("요청 검증 예외 발생 - 메시지: {}", errorMessage);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(errorMessage, 400));
@@ -33,6 +37,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException ex) {
+        if (ex.getStatus().is5xxServerError()) {
+            log.error("서버 예외 발생 - 상태 코드: {}, 메시지: {}", ex.getStatus(), ex.getMessage(), ex);
+            return ResponseEntity
+                    .status(ex.getStatus())
+                    .body(ApiResponse.error("서버 오류가 발생했습니다.", ex.getStatus().value()));
+        }
+
+        log.warn("비즈니스 예외 발생 - 상태 코드: {}, 메시지: {}", ex.getStatus(), ex.getMessage());
         return ResponseEntity
                 .status(ex.getStatus())
                 .body(ApiResponse.error(ex.getMessage(), ex.getStatus().value()));

--- a/src/main/java/org/nova/backend/shared/util/LogMaskingUtil.java
+++ b/src/main/java/org/nova/backend/shared/util/LogMaskingUtil.java
@@ -1,0 +1,47 @@
+package org.nova.backend.shared.util;
+
+public final class LogMaskingUtil {
+
+    private LogMaskingUtil() {
+    }
+
+    public static String maskName(String name) {
+        if (name == null || name.isBlank()) {
+            return "-";
+        }
+
+        if (name.length() == 1) {
+            return "*";
+        }
+
+        if (name.length() == 2) {
+            return name.charAt(0) + "*";
+        }
+
+        return name.charAt(0) + "*".repeat(name.length() - 2) + name.charAt(name.length() - 1);
+    }
+
+    public static String maskEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return "-";
+        }
+
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 0 || atIndex == email.length() - 1) {
+            return "***";
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domainPart = email.substring(atIndex);
+
+        if (localPart.length() == 1) {
+            return "*" + domainPart;
+        }
+
+        if (localPart.length() == 2) {
+            return localPart.charAt(0) + "*" + domainPart;
+        }
+
+        return localPart.charAt(0) + "***" + localPart.charAt(localPart.length() - 1) + domainPart;
+    }
+}

--- a/src/test/java/org/nova/backend/board/common/application/service/BasePostServiceTest.java
+++ b/src/test/java/org/nova/backend/board/common/application/service/BasePostServiceTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 
@@ -204,7 +205,7 @@ class BasePostServiceTest extends AbstractIntegrationTest {
         BasePostRequest request = new BasePostRequest("제목", "내용", PostType.FREE, fileIds);
 
         when(boardUseCase.getBoardById(integratedBoard.getId())).thenReturn(integratedBoard);
-        when(fileUseCase.findFilesByIds(fileIds)).thenThrow(new BoardDomainException("파일을 찾을 수 없습니다"));
+        when(fileUseCase.findFilesByIds(fileIds)).thenThrow(new BoardDomainException("파일을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         Throwable thrown = catchThrowable(() -> basePostService.createPost(integratedBoard.getId(), request, normalUser.getId()));
         assertThat(thrown).isInstanceOf(BoardDomainException.class)

--- a/src/test/java/org/nova/backend/shared/exception/GlobalExceptionHandlerVerificationTest.java
+++ b/src/test/java/org/nova/backend/shared/exception/GlobalExceptionHandlerVerificationTest.java
@@ -1,0 +1,146 @@
+package org.nova.backend.shared.exception;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.nova.backend.auth.UnauthorizedException;
+import org.nova.backend.board.common.adapter.web.CommentController;
+import org.nova.backend.board.common.adapter.web.FileController;
+import org.nova.backend.board.common.application.dto.request.UpdateCommentRequest;
+import org.nova.backend.board.common.application.port.in.CommentUseCase;
+import org.nova.backend.board.common.application.port.in.FileUseCase;
+import org.nova.backend.board.common.domain.exception.BoardDomainException;
+import org.nova.backend.board.common.domain.exception.CommentDomainException;
+import org.nova.backend.board.common.domain.exception.FileDomainException;
+import org.nova.backend.board.util.SecurityUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerVerificationTest {
+
+    @Mock
+    private CommentUseCase commentUseCase;
+
+    @Mock
+    private FileUseCase fileUseCase;
+
+    @Mock
+    private SecurityUtil securityUtil;
+
+    private MockMvc mockMvc;
+
+
+    @BeforeEach
+    void setUp() {
+        CommentController commentController = new CommentController(commentUseCase, securityUtil);
+        FileController fileController = new FileController(fileUseCase, securityUtil);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(
+                        commentController,
+                        fileController,
+                        new TestExceptionController()
+                )
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void boardDomainException_shouldReturnConfigured404() throws Exception {
+        UUID postId = UUID.randomUUID();
+
+        when(commentUseCase.getCommentsByPostId(postId))
+                .thenThrow(new BoardDomainException("게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/posts/{postId}/comments", postId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void commentDomainException_shouldReturnConfigured403() throws Exception {
+        UUID commentId = UUID.randomUUID();
+        UUID memberId = UUID.randomUUID();
+
+        when(securityUtil.getCurrentMemberId()).thenReturn(memberId);
+        when(commentUseCase.updateComment(any(UUID.class), any(UpdateCommentRequest.class), any(UUID.class)))
+                .thenThrow(new CommentDomainException("자신의 댓글만 수정할 수 있습니다.", HttpStatus.FORBIDDEN));
+
+        mockMvc.perform(put("/api/v1/comments/{commentId}", commentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"updated\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("자신의 댓글만 수정할 수 있습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void fileDomainException_shouldReturnConfigured403() throws Exception {
+        UUID fileId = UUID.randomUUID();
+        UUID memberId = UUID.randomUUID();
+
+        when(securityUtil.getCurrentMemberId()).thenReturn(memberId);
+        org.mockito.Mockito.doThrow(new FileDomainException("게시글 작성자만 파일을 삭제할 수 있습니다.", HttpStatus.FORBIDDEN))
+                .when(fileUseCase).deleteFileById(fileId, memberId);
+
+        mockMvc.perform(delete("/api/v1/files/{fileId}", fileId))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("게시글 작성자만 파일을 삭제할 수 있습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void unauthorizedException_shouldReturn403() throws Exception {
+        mockMvc.perform(get("/test-exceptions/forbidden"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("권한이 없습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void genericException_shouldReturnGeneric500Message() throws Exception {
+        mockMvc.perform(get("/test-exceptions/generic"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @RestController
+    @RequestMapping("/test-exceptions")
+    static class TestExceptionController {
+
+        @GetMapping("/forbidden")
+        List<String> forbidden() {
+            throw new UnauthorizedException("권한이 없습니다.");
+        }
+
+        @GetMapping("/generic")
+        HttpServletResponse generic() {
+            throw new RuntimeException("boom");
+        }
+    }
+}


### PR DESCRIPTION
Closes #154 

## 요약
  - 게시판/파일/댓글/인가 예외를 `CustomException` 기반으로 통일했습니다.
  - 비밀번호 초기화 및 메일 발송 로그를 추가했습니다.

  ## 주요 변경 사항

  ### 1. 예외 처리 통일
  - `BoardDomainException`, `FileDomainException`, `CommentDomainException`, `UnauthorizedException`를 `CustomException` 기반으로 변경
  - 주요 throw 지점에 `HttpStatus` 명시
  - 기존에 500으로 처리되던 일부 비즈니스 예외를 4xx로 정리

  ### 2. 비밀번호 초기화 및 메일 로그 개선
  - `reset-password` 흐름에 실행 지점 로그 추가
  - 메일 발송 실패 시 stack trace 로그 출력

  ## 검증
  - `./gradlew -g /tmp/gradle-home compileJava`
  - `./gradlew -g /tmp/gradle-home test --tests org.nova.backend.shared.exception.GlobalExceptionHandlerVerificationTest`