### PR TITLE
fix: 댓글 삭제 시 대댓글 미삭제 및 commentCount 불일치 버그 수정

### DIFF
--- a/src/integrationTest/java/org/nova/backend/board/common/application/service/CommentServiceTest.java
+++ b/src/integrationTest/java/org/nova/backend/board/common/application/service/CommentServiceTest.java
@@ -1,17 +1,6 @@
 package org.nova.backend.board.common.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import jakarta.persistence.EntityManager;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +28,16 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @Import(CommentServiceTest.MockConfig.class)
 class CommentServiceTest extends AbstractIntegrationTest {
@@ -78,7 +77,6 @@ class CommentServiceTest extends AbstractIntegrationTest {
                 0,
                 0,
                 0,
-                new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
                 LocalDateTime.now(),
@@ -152,27 +150,27 @@ class CommentServiceTest extends AbstractIntegrationTest {
                 .hasMessageContaining("자신의 댓글만 수정");
     }
 
-//    @Test
-//    @DisplayName("댓글 삭제 시 자식 댓글까지 함께 삭제되어야 한다")
-//    @Transactional
-//    void 댓글_삭제_자식까지() {
-//        UUID parentId = commentService.addComment(post.getId(), new CommentRequest(null, "부모"), writer.getId())
-//                .getId();
-//        commentService.addComment(post.getId(), new CommentRequest(parentId, "자식"), other.getId());
-//        assertThat(post.getCommentCount()).isEqualTo(2);
-//
-//        commentService.deleteComment(parentId, writer.getId());
-//
-//        entityManager.flush();
-//        entityManager.clear();
-//
-//        assertThat(commentRepository.existsById(parentId)).isFalse();
-//        assertThat(commentRepository.findAllByParentCommentId(parentId)).isEmpty();
-//
-//        assertThat(postRepository.findById(post.getId()).orElseThrow()
-//                .getCommentCount())
-//                .isZero();
-//    }
+    @Test
+    @DisplayName("댓글 삭제 시 자식 댓글까지 함께 삭제되어야 한다")
+    @Transactional
+    void 댓글_삭제_자식까지() {
+        UUID parentId = commentService.addComment(post.getId(), new CommentRequest(null, "부모"), writer.getId())
+                .getId();
+        commentService.addComment(post.getId(), new CommentRequest(parentId, "자식"), other.getId());
+        assertThat(post.getCommentCount()).isEqualTo(2);
+
+        commentService.deleteComment(parentId, writer.getId());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(commentRepository.existsById(parentId)).isFalse();
+        assertThat(commentRepository.findAllByParentCommentId(parentId)).isEmpty();
+
+        assertThat(postRepository.findById(post.getId()).orElseThrow()
+                .getCommentCount())
+                .isZero();
+    }
 
     @Test
     @DisplayName("작성자가 아니고 관리자도 아닌 사용자가 댓글 삭제 시 예외 발생")
@@ -191,8 +189,13 @@ class CommentServiceTest extends AbstractIntegrationTest {
     void 관리자_댓글_삭제() {
         UUID commentId = commentService.addComment(post.getId(), new CommentRequest(null, "부모"), writer.getId())
                 .getId();
+
         commentService.deleteComment(commentId, admin.getId());
-        assertThat(commentRepository.findById(commentId)).isNotPresent();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(postRepository.findById(post.getId()).orElseThrow().getCommentCount()).isZero();
     }
 
     @Test

--- a/src/main/java/org/nova/backend/board/clubArchive/application/service/JokboPostService.java
+++ b/src/main/java/org/nova/backend/board/clubArchive/application/service/JokboPostService.java
@@ -1,23 +1,6 @@
 package org.nova.backend.board.clubArchive.application.service;
 
-import org.nova.backend.board.common.domain.model.valueobject.BoardCategory;
-import org.nova.backend.board.util.SecurityUtil;
-import org.nova.backend.board.util.ValidationUtil;
-import org.springframework.transaction.annotation.Transactional;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.nova.backend.board.common.application.port.in.BoardUseCase;
-import org.nova.backend.board.common.application.port.in.FileUseCase;
-import org.nova.backend.board.common.application.port.out.BasePostPersistencePort;
-import org.nova.backend.board.common.application.port.out.PostLikePersistencePort;
-import org.nova.backend.board.common.domain.exception.BoardDomainException;
-import org.nova.backend.board.common.domain.model.entity.Board;
-import org.nova.backend.board.common.domain.model.entity.File;
-import org.nova.backend.board.common.domain.model.entity.Post;
-import org.nova.backend.board.common.domain.model.valueobject.PostType;
 import org.nova.backend.board.clubArchive.application.dto.request.JokboPostRequest;
 import org.nova.backend.board.clubArchive.application.dto.request.UpdateJokboPostRequest;
 import org.nova.backend.board.clubArchive.application.dto.response.JokboPostDetailResponse;
@@ -28,6 +11,18 @@ import org.nova.backend.board.clubArchive.application.port.out.JokboPostPersiste
 import org.nova.backend.board.clubArchive.domain.model.entity.JokboPost;
 import org.nova.backend.board.clubArchive.domain.model.valueobject.Semester;
 import org.nova.backend.board.common.adapter.persistence.repository.PostRepository;
+import org.nova.backend.board.common.application.port.in.BoardUseCase;
+import org.nova.backend.board.common.application.port.in.FileUseCase;
+import org.nova.backend.board.common.application.port.out.BasePostPersistencePort;
+import org.nova.backend.board.common.application.port.out.PostLikePersistencePort;
+import org.nova.backend.board.common.domain.exception.BoardDomainException;
+import org.nova.backend.board.common.domain.model.entity.Board;
+import org.nova.backend.board.common.domain.model.entity.File;
+import org.nova.backend.board.common.domain.model.entity.Post;
+import org.nova.backend.board.common.domain.model.valueobject.BoardCategory;
+import org.nova.backend.board.common.domain.model.valueobject.PostType;
+import org.nova.backend.board.util.SecurityUtil;
+import org.nova.backend.board.util.ValidationUtil;
 import org.nova.backend.member.adapter.repository.MemberRepository;
 import org.nova.backend.member.domain.exception.MemberDomainException;
 import org.nova.backend.member.domain.model.entity.Member;
@@ -38,6 +33,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -95,7 +96,6 @@ public class JokboPostService implements JokboPostUseCase {
                 0,
                 0,
                 0,
-                new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
                 LocalDateTime.now(),

--- a/src/main/java/org/nova/backend/board/clubArchive/application/service/PicturePostService.java
+++ b/src/main/java/org/nova/backend/board/clubArchive/application/service/PicturePostService.java
@@ -1,10 +1,5 @@
 package org.nova.backend.board.clubArchive.application.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.nova.backend.auth.UnauthorizedException;
 import org.nova.backend.board.clubArchive.application.dto.request.PicturePostRequest;
@@ -32,6 +27,12 @@ import org.nova.backend.member.domain.model.valueobject.Role;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +78,6 @@ public class PicturePostService implements PicturePostUseCase {
                 0,
                 0,
                 0,
-                new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
                 LocalDateTime.now(),

--- a/src/main/java/org/nova/backend/board/common/adapter/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/org/nova/backend/board/common/adapter/persistence/CommentPersistenceAdapter.java
@@ -1,17 +1,19 @@
 package org.nova.backend.board.common.adapter.persistence;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.nova.backend.board.common.adapter.persistence.repository.CommentRepository;
 import org.nova.backend.board.common.application.port.out.CommentPersistencePort;
 import org.nova.backend.board.common.domain.model.entity.Comment;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
 public class CommentPersistenceAdapter implements CommentPersistencePort {
+
     private final CommentRepository commentRepository;
 
     @Override
@@ -30,12 +32,22 @@ public class CommentPersistenceAdapter implements CommentPersistencePort {
     }
 
     @Override
-    public void deleteById(UUID commentId) {
-        commentRepository.deleteById(commentId);
+    public List<Comment> findAllByParentId(UUID parentId) {
+        return commentRepository.findAllByParentCommentId(parentId);
     }
 
     @Override
-    public List<Comment> findAllByParentId(UUID parentId) {
-        return commentRepository.findAllByParentCommentId(parentId);
+    public long countByParentId(UUID parentId) {
+        return commentRepository.countByParentCommentId(parentId);
+    }
+
+    @Override
+    public void deleteAllByParentId(UUID parentId) {
+        commentRepository.deleteAllByParentCommentId(parentId);
+    }
+
+    @Override
+    public void deleteComment(UUID commentId) {
+        commentRepository.deleteByCommentId(commentId);
     }
 }

--- a/src/main/java/org/nova/backend/board/common/adapter/persistence/repository/CommentRepository.java
+++ b/src/main/java/org/nova/backend/board/common/adapter/persistence/repository/CommentRepository.java
@@ -1,13 +1,29 @@
 package org.nova.backend.board.common.adapter.persistence.repository;
 
-import java.util.List;
-import java.util.UUID;
 import org.nova.backend.board.common.domain.model.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
+
     List<Comment> findAllByParentCommentId(UUID parentCommentId);
+
     List<Comment> findAllByPostIdOrderByCreatedTimeAsc(UUID postId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from Comment c where c.parentComment.id = :parentCommentId")
+    void deleteAllByParentCommentId(@Param("parentCommentId") UUID parentCommentId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from Comment c where c.id = :commentId")
+    void deleteByCommentId(@Param("commentId") UUID commentId);
+
+    long countByParentCommentId(UUID parentCommentId);
 }

--- a/src/main/java/org/nova/backend/board/common/application/mapper/BasePostMapper.java
+++ b/src/main/java/org/nova/backend/board/common/application/mapper/BasePostMapper.java
@@ -1,9 +1,5 @@
 package org.nova.backend.board.common.application.mapper;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.nova.backend.board.common.application.dto.request.BasePostRequest;
 import org.nova.backend.board.common.application.dto.response.BasePostDetailResponse;
@@ -13,6 +9,11 @@ import org.nova.backend.board.common.domain.model.entity.Board;
 import org.nova.backend.board.common.domain.model.entity.Post;
 import org.nova.backend.member.domain.model.entity.Member;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Component
 @AllArgsConstructor
@@ -34,7 +35,6 @@ public class BasePostMapper {
                 0,
                 0,
                 0,
-                new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
                 LocalDateTime.now(),

--- a/src/main/java/org/nova/backend/board/common/application/port/out/CommentPersistencePort.java
+++ b/src/main/java/org/nova/backend/board/common/application/port/out/CommentPersistencePort.java
@@ -1,14 +1,23 @@
 package org.nova.backend.board.common.application.port.out;
 
+import org.nova.backend.board.common.domain.model.entity.Comment;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.nova.backend.board.common.domain.model.entity.Comment;
 
 public interface CommentPersistencePort {
     Comment save(Comment comment);
+
     List<Comment> findAllByPostId(UUID postId);
+
     Optional<Comment> findById(UUID commentId);
-    void deleteById(UUID commentId);
+
     List<Comment> findAllByParentId(UUID parentId);
+
+    long countByParentId(UUID parentId);
+
+    void deleteAllByParentId(UUID parentId);
+
+    void deleteComment(UUID commentId);
 }

--- a/src/main/java/org/nova/backend/board/common/application/service/CommentService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/CommentService.java
@@ -1,18 +1,13 @@
 package org.nova.backend.board.common.application.service;
 
-import org.nova.backend.notification.application.port.in.NotificationUseCase;
-import org.nova.backend.notification.domain.model.entity.valueobject.EventType;
-import org.springframework.transaction.annotation.Transactional;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.nova.backend.board.common.application.dto.request.CommentRequest;
 import org.nova.backend.board.common.application.dto.request.UpdateCommentRequest;
 import org.nova.backend.board.common.application.dto.response.CommentResponse;
 import org.nova.backend.board.common.application.mapper.CommentMapper;
 import org.nova.backend.board.common.application.port.in.CommentUseCase;
-import org.nova.backend.board.common.application.port.out.CommentPersistencePort;
 import org.nova.backend.board.common.application.port.out.BasePostPersistencePort;
+import org.nova.backend.board.common.application.port.out.CommentPersistencePort;
 import org.nova.backend.board.common.domain.exception.BoardDomainException;
 import org.nova.backend.board.common.domain.exception.CommentDomainException;
 import org.nova.backend.board.common.domain.model.entity.Comment;
@@ -20,10 +15,16 @@ import org.nova.backend.board.common.domain.model.entity.Post;
 import org.nova.backend.member.adapter.repository.MemberRepository;
 import org.nova.backend.member.domain.model.entity.Member;
 import org.nova.backend.member.domain.model.valueobject.Role;
+import org.nova.backend.notification.application.port.in.NotificationUseCase;
+import org.nova.backend.notification.domain.model.entity.valueobject.EventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -81,14 +82,11 @@ public class CommentService implements CommentUseCase {
 
         Post post = comment.getPost();
 
-        List<Comment> children = commentPersistencePort.findAllByParentId(commentId);
-        children.forEach(c -> commentPersistencePort.deleteById(c.getId()));
-        commentPersistencePort.deleteById(commentId);
+        long childCount = commentPersistencePort.countByParentId(commentId);
+        post.decrementCommentCount((int) childCount + 1);
 
-        post.getComments().removeAll(children);
-        post.getComments().remove(comment);
-
-        post.decrementCommentCount(children.size() + 1);
+        commentPersistencePort.deleteAllByParentId(commentId);
+        commentPersistencePort.deleteComment(commentId);
     }
 
 
@@ -116,7 +114,6 @@ public class CommentService implements CommentUseCase {
 
         Comment comment = commentMapper.toEntity(request, post, member, parentComment);
         comment = commentPersistencePort.save(comment);
-        post.getComments().add(comment);
 
         if (parentComment == null) {
             // 일반 댓글 → 게시글 작성자에게 알림

--- a/src/main/java/org/nova/backend/board/common/domain/model/entity/Post.java
+++ b/src/main/java/org/nova/backend/board/common/domain/model/entity/Post.java
@@ -1,26 +1,16 @@
 package org.nova.backend.board.common.domain.model.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.nova.backend.board.common.domain.model.valueobject.PostType;
 import org.nova.backend.member.domain.model.entity.Member;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -69,9 +59,6 @@ public class Post {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<File> files = new ArrayList<>();
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostLike> likes = new ArrayList<>();


### PR DESCRIPTION
## 변경 사항                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                        
  ### 버그
  댓글 삭제 시 대댓글(자식 댓글)이 함께 삭제되지 않아 고아 레코드가 남고,                                                                                                                                                                               
  `Post.commentCount`가 실제 댓글 수와 달라지는 문제 발생                                                                                                                                                                                        
                                                                                                                                                                                                                                                        
  기존 구현은 `commentRepository.deleteById()`를 사용해 부모 댓글만 제거했기 때문에,                                                                                                                                                                    
  대댓글이 존재하는 경우 DB에 잔류하며 `commentCount` 차감도 1만 이루어짐                                                                                                                                                                            
                                                                                                                                                                                                                                                        
  ### 수정 내용                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                        
  **댓글 삭제 로직 교체**                                                                                                                                                                                                                               
  - `CommentRepository`에 `@Modifying` JPQL 벌크 삭제 쿼리 추가
    - `deleteAllByParentCommentId` — 자식 댓글 일괄 삭제                                                                                                                                                                                                
    - `deleteByCommentId` — 부모 댓글 삭제                                                                                                                                                                                                            
    - `countByParentCommentId` — 자식 댓글 수 카운트                                                                                                                                                                                                    
  - `CommentPersistencePort` / `CommentPersistenceAdapter` 인터페이스 및 구현체 교체                                                                                                                                                                  
  - `CommentService.deleteComment()`에서 자식 수 카운트 후 `Post.decrementCommentCount(childCount + 1)` 적용                                                                                                                                            
                                                                                                                                                                                                                                                        
  **Post 생성자 정리**                                                                                                                                                                                                                                  
  - 사용되지 않던 `ArrayList<>` 파라미터 제거 (JokboPostService, PicturePostService, BasePostMapper, CommentServiceTest)                                                                                                                           
                                                                                                                                                                                                                                                        
  **테스트**
  - 주석 처리돼 있던 자식 댓글 삭제 통합 테스트 복원                                                                                                                                                                                                    
  - 관리자 삭제 테스트에 `entityManager.flush()/clear()` 추가해 1차 캐시 우회 후 검증                                                                                                                                                                   
                                                                                                                                                                                                                                                        
  ### 변경 전/후                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                        
  | 항목 | 변경 전 | 변경 후 |                                                                                                                                                                                                                          
  |---|---|---|                                                                                                                                                                                                                                       
  | 자식 댓글 삭제 | 미삭제 (고아 레코드 잔류) | `deleteAllByParentCommentId` 벌크 삭제 |
  | commentCount 차감 | 항상 -1 | -(자식 수 + 1) |                                                                                                                                                                                                      
  | 삭제 메서드 | `deleteById` | `deleteAllByParentId` → `deleteComment` 순서 보장 | 