### PR TITLE
fix: 인증 세션 불일치 해결 및 Redis/Executor 자원 관리 최적화

### DIFF
--- a/src/main/java/org/nova/backend/board/common/application/service/FileService.java
+++ b/src/main/java/org/nova/backend/board/common/application/service/FileService.java
@@ -1,5 +1,6 @@
 package org.nova.backend.board.common.application.service;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.nova.backend.board.common.application.dto.response.FileResponse;
@@ -71,6 +73,11 @@ public class FileService implements FileUseCase {
             String fileName = file.getId() + "." + extension;
             Path publicFilePath = Paths.get(baseFileStoragePath, FilePathConstants.PUBLIC_FOLDER, fileName);
             FileStorageUtil.deleteFile(publicFilePath.toString());
+
+            redisTemplate.delete(List.of(
+                    FileCacheKeyConstants.uploadStatusKey(file.getId()),
+                    FileCacheKeyConstants.imageMetaKey(file.getId())
+            ));
         }
         filePersistencePort.deleteFilesByIds(fileIds);
     }
@@ -168,7 +175,7 @@ public class FileService implements FileUseCase {
 
         if (postType == PostType.PICTURES) {
             copyFileToPublic(savedFilePath, storagePath, fileId, extension);
-            redisTemplate.opsForValue().set("upload:" + fileId, "uploading");
+            redisTemplate.opsForValue().set(FileCacheKeyConstants.uploadStatusKey(fileId), "uploading", 7, TimeUnit.DAYS);
             CompletableFuture.runAsync(() ->
                     compressImageAsync(fileId, savedFilePath, storagePath, extension), executor);
         }
@@ -208,7 +215,7 @@ public class FileService implements FileUseCase {
         logger.info("[압축 시작] fileId={} thread={}", fileId, threadName);
 
         try {
-            redisTemplate.opsForValue().set("upload:" + fileId, "compressing");
+            redisTemplate.opsForValue().set(FileCacheKeyConstants.uploadStatusKey(fileId), "compressing", 7, TimeUnit.DAYS);
 
             Path protectedPath = Paths.get(originalFilePath);
             Path publicDir = Paths.get(storagePath, FilePathConstants.PUBLIC_FOLDER);
@@ -217,14 +224,15 @@ public class FileService implements FileUseCase {
 
             redisTemplate.opsForValue().set(
                     FileCacheKeyConstants.imageMetaKey(fileId),
-                    compressResult.originalWidth() + "x" + compressResult.originalHeight()
+                    compressResult.originalWidth() + "x" + compressResult.originalHeight(),
+                    30, TimeUnit.DAYS
             );
 
-            redisTemplate.opsForValue().set("upload:" + fileId, "done");
+            redisTemplate.opsForValue().set(FileCacheKeyConstants.uploadStatusKey(fileId), "done", 7, TimeUnit.DAYS);
             logger.info("[압축 완료] fileId={}", fileId);
         } catch (Exception e) {
             logger.error("이미지 압축 중 오류", e);
-            redisTemplate.opsForValue().set("upload:" + fileId, "error");
+            redisTemplate.opsForValue().set(FileCacheKeyConstants.uploadStatusKey(fileId), "error", 7, TimeUnit.DAYS);
         }
     }
 
@@ -261,6 +269,11 @@ public class FileService implements FileUseCase {
         String extension = FileUtil.getFileExtension(file.getOriginalFilename());
         Path publicPath = Paths.get(baseFileStoragePath, FilePathConstants.PUBLIC_FOLDER, file.getId() + "." + extension);
         FileStorageUtil.deleteFile(publicPath.toString());
+
+        redisTemplate.delete(List.of(
+                FileCacheKeyConstants.uploadStatusKey(fileId),
+                FileCacheKeyConstants.imageMetaKey(fileId)
+        ));
 
         filePersistencePort.deleteFileById(fileId);
     }
@@ -323,5 +336,18 @@ public class FileService implements FileUseCase {
             basePostPersistencePort.save(file.getPost());
         }
         filePersistencePort.save(file);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/org/nova/backend/board/util/FileCacheKeyConstants.java
+++ b/src/main/java/org/nova/backend/board/util/FileCacheKeyConstants.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public final class FileCacheKeyConstants {
     public static final String IMAGE_META_PREFIX = "image:meta:";
+    public static final String UPLOAD_STATUS_PREFIX = "upload:";
 
     private FileCacheKeyConstants() {
         throw new UnsupportedOperationException("상수 클래스는 인스턴스화할 수 없습니다.");
@@ -11,5 +12,9 @@ public final class FileCacheKeyConstants {
 
     public static String imageMetaKey(UUID fileId) {
         return IMAGE_META_PREFIX + fileId;
+    }
+
+    public static String uploadStatusKey(UUID fileId) {
+        return UPLOAD_STATUS_PREFIX + fileId;
     }
 }

--- a/src/main/java/org/nova/backend/shared/security/LoginFilter.java
+++ b/src/main/java/org/nova/backend/shared/security/LoginFilter.java
@@ -121,7 +121,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String name = customUserDetails.getUsername();
         String role = SecurityUtils.getRole(authentication);
 
-        return jwtUtil.createJwt(studentNumber, name, role, 60 * 60 * 60 * 10L);
+        return jwtUtil.createJwt(studentNumber, name, role, 60 * 60 * 5 * 1000L);
     }
 
     @Override


### PR DESCRIPTION
## 변경 사항
- 사용자 인증 세션의 불일치 문제 해결
- Redis 메모리 누수 및 애플리케이션 종료 시 발생할 수 있는 자원 손실 문제를 개선

## 변경 이유
1. 인증 및 보안
- JWT 만료 시간 정정: 기존 계산식 오류로 인해 JWT가 36분 만에 만료되어, 쿠키가 살아있음에도 갑자기 로그아웃되는 현상을 수정
- 60 * 60 * 5 * 1000L (5시간)으로 수정하여 쿠키 유효기간과 동기화

2. Redis 및 자원 관리
- Redis TTL 및 자동 정리: upload:{fileId} (7일), image:meta:{fileId} (30일) TTL을 부여하여 메모리 손실 방지
- 파일 삭제(deleteFiles, deleteFileById) 시 관련 Redis 키를 즉시 삭제하도록 로직을 추가
- 하드코딩된 "upload:" 문자열을 FileCacheKeyConstants.uploadStatusKey()로 통합 관리
- FileService 종료 시 @PreDestroy를 통해 진행 중인 압축 작업을 최대 30초간 대기 후 종료하도록 설정하여 .tmp 파일 잔류 문제를 방지

## 변경 전/후
**<html><head></head><body>
항목 | 변경 전 | 변경 후
-- | -- | --
JWT 만료 시간 | 36분 (60 * 60 * 60 * 10L) | 5시간 (60 * 60 * 5 * 1000L)
사용자 경험 | 36분 후 갑작스러운 401 에러 | 쿠키 만료 시까지 세션 유지
Redis 키 TTL | 없음 (영구 잔류) | 7일 / 30일 설정
파일 삭제 시 Redis | 데이터 잔류 (메모리 누수) | 즉시 삭제 (정리)
애플리케이션 종료 | Executor 미종료 (작업 손실 가능) | Graceful Shutdown (30초 대기)

</body></html>**

## 테스트
- [X] 로컬 테스트 완료
- [X] 기존 기능 정상 동작 확인