### PR TITLE
fix: cicd 테스트 분리 및 docker image 버전 명시

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -59,6 +59,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Create .env file for CI
+        run: |
+          cat <<EOF > .env
+          MYSQL_DATABASE=test_db
+          MYSQL_USER=test_user
+          MYSQL_PASSWORD=test_pw
+          MYSQL_ROOT_PASSWORD=test_root_pw
+          MYSQL_HOST=127.0.0.1
+          MYSQL_IN_PORT=3306
+          MYSQL_EX_PORT=3307
+          REDIS_HOST=127.0.0.1
+          REDIS_PORT=6379
+          SPRING_PROFILE_ACTIVE=test
+          SPRING_APP_PORT=4001
+          FILE_STORAGE_PATH=/tmp/test-storage
+          JWT_SECRET_KEY=dummysecret
+          EMAIL_ADDRESS=test@example.com
+          EMAIL_PASSWORD=1234
+          BASE_PROFILE_IMAGE_NAME=default.png
+          ADMIN_STUDENT_NUMBER=12345678
+          ADMIN_PASSWORD=1234
+          EOF
+
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,6 @@ services:
     restart: unless-stopped
     environment:
       - JENKINS_PORT=${JENKINS_PORT}
-      - TESTCONTAINERS_NETWORK=backend_backend_network
     networks:
       - 'backend_network'
     healthcheck:
@@ -25,7 +24,7 @@ services:
       start_period: 60s
 
   mysql:
-    image: 'mysql:latest'
+    image: 'mysql:8.4'
     environment:
       - 'MYSQL_DATABASE=${MYSQL_DATABASE}'
       - 'MYSQL_USER=${MYSQL_USER}'
@@ -46,7 +45,7 @@ services:
       - 'backend_network'
 
   redis:
-    image: 'redis:latest'
+    image: 'redis:7'
     ports:
       - "${REDIS_PORT}:6379"
     restart: unless-stopped


### PR DESCRIPTION
## 변경 사항
- jenkins의 자원 점유율이 높아 ci, cd를 github Action과 Jenkins로 분리
- 도커버전 이미지 명시

## 테스트
- [X] 로컬 테스트 완료
- [X] 기존 기능 정상 동작 확인